### PR TITLE
Use colors.cursor instead of cursor.color

### DIFF
--- a/rose-pine
+++ b/rose-pine
@@ -1,9 +1,6 @@
 # -*- conf -*-
 # Rosé Pine
 
-[cursor]
-color=191724 e0def4 
-
 [colors]
 background=191724 
 foreground=e0def4 
@@ -28,3 +25,4 @@ bright7=fefcff      # bright white (lighter Text)
 
 flash=f6c177        # yellow (Gold)
 
+cursor=191724 e0def4 

--- a/rose-pine-dawn
+++ b/rose-pine-dawn
@@ -1,9 +1,6 @@
 # -*- conf -*-
 # Rosé Pine Dawn
 
-[cursor]
-color=faf4ed 575279
-
 [colors]
 background=faf4ed
 foreground=575279
@@ -28,3 +25,4 @@ bright7=7c76a0      # bright white (lighter Text)
 
 flash=ea9d34        # yellow (Gold)
 
+cursor=faf4ed 575279

--- a/rose-pine-moon
+++ b/rose-pine-moon
@@ -1,9 +1,6 @@
 # -*- conf -*-
 # Rosé Pine Moon
 
-[cursor]
-color=232136 e0def4
-
 [colors]
 background=232136
 foreground=e0def4
@@ -28,3 +25,4 @@ bright7=fefcff      # bright white (lighter Text)
 
 flash=f6c177        # yellow (Gold)
 
+cursor=232136 e0def4


### PR DESCRIPTION
Title. Foot has deprecated `cursor.color` since a few versions, and `colors.cursor` is now used instead.