### PR TITLE
foot 1.26.0 - replacing [colors] and [colors2]

### DIFF
--- a/rose-pine
+++ b/rose-pine
@@ -1,9 +1,9 @@
 # -*- conf -*-
 # Rosé Pine
 
-[colors]
-background=191724 
-foreground=e0def4 
+[colors-dark]
+background=191724
+foreground=e0def4
 
 regular0=26233a     # black (Overlay)
 regular1=eb6f92     # red (Love)
@@ -25,4 +25,4 @@ bright7=fefcff      # bright white (lighter Text)
 
 flash=f6c177        # yellow (Gold)
 
-cursor=191724 e0def4 
+cursor=191724 e0def4

--- a/rose-pine-dawn
+++ b/rose-pine-dawn
@@ -1,7 +1,10 @@
 # -*- conf -*-
 # Rosé Pine Dawn
 
-[colors]
+[main]
+initial-color-theme=light
+
+[colors-light]
 background=faf4ed
 foreground=575279
 

--- a/rose-pine-moon
+++ b/rose-pine-moon
@@ -1,7 +1,7 @@
 # -*- conf -*-
 # Rosé Pine Moon
 
-[colors]
+[colors-dark]
 background=232136
 foreground=e0def4
 


### PR DESCRIPTION
https://codeberg.org/dnkl/foot/commit/cf2b390f6e096e7a2ca93d4dece153eb13261a2e

as written in the commit,
I think it is better to explain the type of theme, between light and dark

also removed some whitespace